### PR TITLE
Remove redundant argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can set the token in this file.
 ```php
 // File: /config/line-notify.php
 return [
-    'access_token' => env('LINE_ACCESS_TOKEN', null),
+    'access_token' => env('LINE_ACCESS_TOKEN'),
 ];
 ```
 

--- a/config/line-notify.php
+++ b/config/line-notify.php
@@ -2,6 +2,6 @@
 
 return [
 
-    'access_token' => env('LINE_ACCESS_TOKEN', null),
+    'access_token' => env('LINE_ACCESS_TOKEN'),
 
 ];


### PR DESCRIPTION
The default value of `env()` helper is `null` by default.